### PR TITLE
fix: compatibility when not using multichar

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -389,3 +389,21 @@ AddEventHandler('esx_skin:openSaveableMenu', function(submitCb, cancelCb)
 		end
 	end, config)
 end)
+
+RegisterNetEvent('esx_skin:playerRegistered')
+AddEventHandler('esx_skin:playerRegistered', function()
+	local config = {
+		ped = true,
+		headBlend = true,
+		faceFeatures = true,
+		headOverlays = true,
+		components = true,
+		props = true
+	}
+	
+	exports['fivem-appearance']:startPlayerCustomization(function (appearance)
+		if appearance then
+			TriggerServerEvent('fivem-appearance:save', appearance)
+		end
+	end, config)	
+end)


### PR DESCRIPTION
esx_identity:

`if not ESX.GetConfig().Multichar then TriggerEvent('esx_skin:playerRegistered') end`

PR add missing compatible event