### PR TITLE
fix client error using esx_skin:openSaveableMenu

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -394,12 +394,12 @@ AddEventHandler('esx_skin:openSaveableMenu', function(submitCb, cancelCb)
 		props = true
 	}
 	
-	exports['fivem-appearance']:startPlayerCustomization(function (appearance)
-		if (appearance) then
-			TriggerServerEvent('fivem-appearance:save', appearance)
-			if submitCb() ~= nil then submitCb() end
-		elseif cancelCb ~= nil then
-			cancelCb()
-		end
-	end, config)
+exports['fivem-appearance']:startPlayerCustomization(function (appearance)
+        if (appearance) then
+            TriggerServerEvent('fivem-appearance:save', appearance)
+            print('Saved')
+        else
+            print('Canceled')
+        end
+    end, config)
 end)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69638603/133027330-92c03b8b-7151-49d8-8b97-e04d9f50937b.png)

PR solves this issue, in cases of using esx_skin:openSaveableMenu while still saving data correctly for esx users.
