### PR TITLE
fix: Actually resolve compatibility with multicharacter

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -394,15 +394,14 @@ AddEventHandler('esx_skin:openSaveableMenu', function(submitCb, cancelCb)
 		components = true,
 		props = true
 	}
-	
 	exports['fivem-appearance']:startPlayerCustomization(function (appearance)
 		if (appearance) then
 			TriggerServerEvent('fivem-appearance:save', appearance)
 			print('Saved')
-			if submitCb and type(submitCb) == 'function' then submitCb() end
+			if submitCb then submitCb() end
 		else
 			print('Canceled')
-			if cancelCb and type(cancelCb) == 'function' then cancelCb() end
+			if cancelCb then cancelCb() end
 		end
 	end, config)
 end)


### PR DESCRIPTION
They're actually tables (metatables) to call, so remove function check