### PR TITLE
Fix outfit name bug

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -324,7 +324,7 @@ RegisterNetEvent('fivem-appearance:saveOutfit', function()
         local pedComponents = exports['fivem-appearance']:getPedComponents(playerPed)
         local pedProps = exports['fivem-appearance']:getPedProps(playerPed)
         Citizen.Wait(500)
-        TriggerServerEvent('fivem-appearance:saveOutfit', keyboard, pedModel, pedComponents, pedProps)
+        TriggerServerEvent('fivem-appearance:saveOutfit', keyboard[1].input, pedModel, pedComponents, pedProps)
         
     end
 end)


### PR DESCRIPTION
With most of nh-keyboards currently available returning tables with _id and input the argument should be
keyboard[1].input instead of keyboard. Makes names show up as [object Object] in menu.